### PR TITLE
Update legacy.ini -restore Human Interface button & OLED

### DIFF
--- a/targets/legacy.ini
+++ b/targets/legacy.ini
@@ -11,9 +11,9 @@ build_flags =
 	-D LORA_PIN_DIO0=26
 	-D LORA_POWER=10
 	; Human Interface
-	;-D PIN_BUTTON=0
+	-D PIN_BUTTON=0
 	-D IO_LED_PIN=2
-	;-D HAS_OLED
+	-D HAS_OLED
 	-D OLED_ADDRESS=0x3c
 	-D OLED_SDA=4
 	-D OLED_SCL=15
@@ -31,9 +31,9 @@ build_flags =
 	-D LORA_PIN_DIO0=26
 	-D LORA_POWER=10
 	; Human Interface
-	;-D PIN_BUTTON=0
+	-D PIN_BUTTON=0
 	-D IO_LED_PIN=2
-	;-D HAS_OLED
+	-D HAS_OLED
 	-D OLED_ADDRESS=0x3c
 	-D OLED_SDA=21
 	-D OLED_SCL=22
@@ -51,9 +51,9 @@ build_flags =
 	-D LORA_PIN_DIO0=26
 	-D LORA_POWER=10
 	; Human Interface
-	;-D PIN_BUTTON=0
+	-D PIN_BUTTON=0
 	-D IO_LED_PIN=2
-	;-D HAS_OLED
+	-D HAS_OLED
 	-D OLED_ADDRESS=0x3c
 	-D OLED_SDA=21
 	-D OLED_SCL=22
@@ -71,9 +71,9 @@ build_flags =
 	-D LORA_PIN_DIO0=26
 	-D LORA_POWER=10
 	; Human Interface
-	;-D PIN_BUTTON=0
+	-D PIN_BUTTON=0
 	-D IO_LED_PIN=2
-	;-D HAS_OLED
+	-D HAS_OLED
 	-D OLED_ADDRESS=0x3c
 	-D OLED_SDA=4
 	-D OLED_SCL=15


### PR DESCRIPTION
Added legacy button and OLED defines back in. 

I do not notice any difference in build warnings with these un-commented.

Note: With or without this change I did need to comment target segment for [env:expresslrs_rx_915_via_WiFi] in order to complete Build All. interestingly the other elrs via wifi targets appear to build ok.