### PR TITLE
Add GNSS Inject

### DIFF
--- a/src/lib/GNSS/GNSSManager.cpp
+++ b/src/lib/GNSS/GNSSManager.cpp
@@ -68,11 +68,20 @@ void GNSSManager::loop()
         }
         providers[i]->loop();
     }
+    for (uint8_t i = 0; i < GNSS_MAX_LISTENERS; i++) {
+        if (listeners[i] == nullptr) {
+            continue;
+        }
+        listeners[i]->update(this->getLocation());
+    }
 }
 
 void GNSSManager::statusJson(JsonDocument *doc)
 {
     (*doc)["activeProvider"] = getCurrentProviderNameShort();
+#ifdef GNSS_INJECT
+    (*doc)["injectingGNSS"] = true;
+#endif
     (*doc)["lat"] = getLocation().lat;
     (*doc)["lon"] = getLocation().lon;
     (*doc)["alt"] = getLocation().alt;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -148,13 +148,18 @@ void setup()
     // Create GNSSManager
     DBGLN("[main] start GNSSManager");
     GNSSManager *gnssManager = GNSSManager::getSingleton();
+#ifndef GNSS_INJECT
     // Use MSP GNSS as our primary provider
     gnssManager->addProvider(new MSP_GNSS());
+#endif
     // Use Direct GNSS if MSP isn't available
 #ifdef GNSS_ENABLED
     gnssManager->addProvider(new Direct_GNSS());
 #endif
-
+#ifdef GNSS_INJECT
+    // Send GNSS updates to a listening FC over MSP (an F411 for example)
+    gnssManager->addListener(new MSP_GNSS());
+#endif
     // Create RadioManager
     DBGLN("[main] start RadioManager");
     RadioManager *radioManager = RadioManager::getSingleton();


### PR DESCRIPTION
Early-stage guarded implementation of #7, this requires a compile-time flag to enable GNSS injection. Once #6 is done, we should move this to be a persistent configuration option.