### PR TITLE
Fix SX1280 power output low #11

### DIFF
--- a/src/lib/Radios/LoRa_SX128X.cpp
+++ b/src/lib/Radios/LoRa_SX128X.cpp
@@ -50,6 +50,8 @@ int LoRa_SX128X::begin() {
 #endif
     radio = new SX1281(new Module(LORA_PIN_CS, LORA_PIN_DIO, LORA_PIN_RST, LORA_PIN_BUSY));
     radio->begin(FREQUENCY, BANDWIDTH, SPREADING_FACTOR, CODING_RATE, SYNC_WORD, LORA_POWER, PREAMBLE_LENGTH);
+    // We appear to need to set this twice
+    radio->setOutputPower(LORA_POWER);
     //radio->setCRC(0);
     #ifdef LORA_PIN_RXEN
     radio->setRfSwitchPins(LORA_PIN_RXEN, LORA_PIN_TXEN);


### PR DESCRIPTION
Setting the SX1280 power output twice in RadioLib seems to actually achieve an approximately-right power output. Haven't tested on 900MHz/433MHz hardware yet.