### PR TITLE
Update expresslrs.ini -fix expresslrs_rx_915_via_WiFi

### DIFF
--- a/targets/expresslrs.ini
+++ b/targets/expresslrs.ini
@@ -63,7 +63,7 @@ build_flags =
 	'-D CFG_TARGET_FULLNAME="ExpressLRS 915MHz RX"'
 
 [env:expresslrs_rx_915_via_WiFi]
-extends = env:expresslrs_rx_915
+extends = env:expresslrs_rx_915_via_UART
 upload_port = 192.168.4.1
 extra_scripts = compressed_ota.py
 upload_protocol = espota


### PR DESCRIPTION
Fix [env:expresslrs_rx_915_via_WiFi] :
extends = env:expresslrs_rx_915
to:
extends = env:expresslrs_rx_915_via_UART

Note: This now appears to build and WiFi upload onto an ES900RX that was most recently flashed via UART with commit 1530d78. However, after upload the verification failed and WiFi is no longer visible. 

I will pull this RX to re-flash via UART and test via WiFi again.