### PR TITLE
Update legacy.ini -re-enable OLED

### DIFF
--- a/targets/legacy.ini
+++ b/targets/legacy.ini
@@ -17,6 +17,7 @@ build_flags =
 	-D OLED_ADDRESS=0x3c
 	-D OLED_SDA=4
 	-D OLED_SCL=15
+ 	-D OLED_RST=16
 [env_lilygo14]
 build_flags =
 	-D SERIAL_PIN_TX=16
@@ -36,6 +37,7 @@ build_flags =
 	-D OLED_ADDRESS=0x3c
 	-D OLED_SDA=21
 	-D OLED_SCL=22
+ 	-D OLED_RST=16
 [env_lilygo16]
 build_flags =
 	-D SERIAL_PIN_TX=23
@@ -55,6 +57,7 @@ build_flags =
 	-D OLED_ADDRESS=0x3c
 	-D OLED_SDA=21
 	-D OLED_SCL=22
+ 	-D OLED_RST=16
 [env_lilygo20]
 build_flags =
 	-D SERIAL_PIN_TX=23
@@ -74,6 +77,7 @@ build_flags =
 	-D OLED_ADDRESS=0x3c
 	-D OLED_SDA=4
 	-D OLED_SCL=15
+ 	-D OLED_RST=16
 
 [env:diy_LoRa_lilygo10_433_via_UART]
 extends = env_common_esp32, env_common_433, env_lilygo10


### PR DESCRIPTION
re-added for all four lillygo board versions:
 	-D OLED_RST=16

Somehow became missing before 4.0.8 release?