### PR TITLE
Update legacy.ini -add Heltec_WiFi_LoRa_32

### DIFF
--- a/targets/legacy.ini
+++ b/targets/legacy.ini
@@ -1,3 +1,23 @@
+[env_Heltec_WiFi_LoRa_32]
+build_flags =
+	-D SERIAL_PIN_TX=23
+	-D SERIAL_PIN_RX=17
+	; LoRa Config
+	-D LORA_PIN_SCK=5
+	-D LORA_PIN_MISO=19
+	-D LORA_PIN_MOSI=27
+	-D LORA_PIN_CS=18
+	-D LORA_PIN_RST=14
+	-D LORA_PIN_DIO0=26
+	-D LORA_POWER=10
+	; Human Interface
+	-D PIN_BUTTON=0
+	-D IO_LED_PIN=25
+	-D HAS_OLED
+	-D OLED_ADDRESS=0x3c
+	-D OLED_SDA=4
+	-D OLED_SCL=15
+ 	-D OLED_RST=16
 [env_lilygo10]
 build_flags =
 	-D SERIAL_PIN_TX=23
@@ -79,6 +99,33 @@ build_flags =
 	-D OLED_SCL=15
  	-D OLED_RST=16
 
+[env:diy_LoRa_Heltec_WiFi_LoRa_32_433_via_UART]
+extends = env_common_esp32, env_common_433, env_Heltec_WiFi_LoRa_32
+build_flags = 
+	${env_common_esp32.build_flags}
+	${env_common_433.build_flags}
+	${env_lilygo10.build_flags}
+	'-D CFG_TARGET_NAME="LL10"'
+	'-D CFG_TARGET_FULLNAME="Heltec WiFi LoRa 32 v1-3 433MHz"'
+
+[env:diy_LoRa_Heltec_WiFi_LoRa_32_868_via_UART]
+extends = env_common_esp32, env_common_868, env_Heltec_WiFi_LoRa_32
+build_flags = 
+	${env_common_esp32.build_flags}
+	${env_common_868.build_flags}
+	${env_lilygo10.build_flags}
+	'-D CFG_TARGET_NAME="LL10"'
+	'-D CFG_TARGET_FULLNAME="Heltec WiFi LoRa 32 v1-3 868MHz"'
+
+[env:diy_LoRa_Heltec_WiFi_LoRa_32_915_via_UART]
+extends = env_common_esp32, env_common_915, env_Heltec_WiFi_LoRa_32
+build_flags = 
+	${env_common_esp32.build_flags}
+	${env_common_915.build_flags}
+	${env_lilygo10.build_flags}
+	'-D CFG_TARGET_NAME="LL10"'
+	'-D CFG_TARGET_FULLNAME="Heltec WiFi LoRa 32 v1-3 915MHz"'
+ 
 [env:diy_LoRa_lilygo10_433_via_UART]
 extends = env_common_esp32, env_common_433, env_lilygo10
 build_flags = 

--- a/targets/legacy.ini
+++ b/targets/legacy.ini
@@ -104,8 +104,8 @@ extends = env_common_esp32, env_common_433, env_Heltec_WiFi_LoRa_32
 build_flags = 
 	${env_common_esp32.build_flags}
 	${env_common_433.build_flags}
-	${env_lilygo10.build_flags}
-	'-D CFG_TARGET_NAME="LL10"'
+	${env_Heltec_WiFi_LoRa_32.build_flags}
+	'-D CFG_TARGET_NAME="HT32"'
 	'-D CFG_TARGET_FULLNAME="Heltec WiFi LoRa 32 v1-3 433MHz"'
 
 [env:diy_LoRa_Heltec_WiFi_LoRa_32_868_via_UART]
@@ -113,8 +113,8 @@ extends = env_common_esp32, env_common_868, env_Heltec_WiFi_LoRa_32
 build_flags = 
 	${env_common_esp32.build_flags}
 	${env_common_868.build_flags}
-	${env_lilygo10.build_flags}
-	'-D CFG_TARGET_NAME="LL10"'
+	${env_Heltec_WiFi_LoRa_32.build_flags}
+	'-D CFG_TARGET_NAME="HT32"'
 	'-D CFG_TARGET_FULLNAME="Heltec WiFi LoRa 32 v1-3 868MHz"'
 
 [env:diy_LoRa_Heltec_WiFi_LoRa_32_915_via_UART]
@@ -122,8 +122,8 @@ extends = env_common_esp32, env_common_915, env_Heltec_WiFi_LoRa_32
 build_flags = 
 	${env_common_esp32.build_flags}
 	${env_common_915.build_flags}
-	${env_lilygo10.build_flags}
-	'-D CFG_TARGET_NAME="LL10"'
+	${env_Heltec_WiFi_LoRa_32.build_flags}
+	'-D CFG_TARGET_NAME="HT32"'
 	'-D CFG_TARGET_FULLNAME="Heltec WiFi LoRa 32 v1-3 915MHz"'
  
 [env:diy_LoRa_lilygo10_433_via_UART]


### PR DESCRIPTION
Added Heltec_WiFi_LoRa_32 target for "Heltec WiFi LoRa 32 v1-3" boards.

Distinctions from lilygo10:
- IO_LED_PIN=25 
- naming