### PR TITLE
Fix craftname detection

### DIFF
--- a/src/lib/MSP/MSPManager.cpp
+++ b/src/lib/MSP/MSPManager.cpp
@@ -40,7 +40,10 @@ uint8_t MSPManager::getState()
 // Requests the name of the flight controller over MSP without caching
 void MSPManager::getName(char *name, size_t length)
 {
-    msp->request(MSP_NAME, name, length);
+    if (!msp->request(MSP_NAME, name, length))
+    {
+        memset(name, 0, length);
+    }
 }
 
 // Returns the MSPHost variant of the flight controller; cached once we have a valid response,
@@ -55,7 +58,10 @@ MSPHost MSPManager::getFCVariant()
     }
     if (!cached)
     {
-        msp->request(MSP_FC_VARIANT, variant, sizeof(variant));
+        if (!msp->request(MSP_FC_VARIANT, variant, sizeof(variant)))
+        {
+            memset(&variant, 0, sizeof(variant));
+        }
     }
     if (strncmp(variant, "INAV", 4) == 0)
     {

--- a/src/lib/MSP/MSPManager.h
+++ b/src/lib/MSP/MSPManager.h
@@ -6,7 +6,7 @@
 #include "../GNSS/GNSSManager.h"
 #include "../Peers/PeerManager.h"
 
-#define HOST_MSP_TIMEOUT 12000
+#define HOST_MSP_TIMEOUT 8500
 
 enum MSPHost {
     HOST_NONE = 0,

--- a/src/lib/MSP/MSPManager.h
+++ b/src/lib/MSP/MSPManager.h
@@ -6,7 +6,7 @@
 #include "../GNSS/GNSSManager.h"
 #include "../Peers/PeerManager.h"
 
-#define HOST_MSP_TIMEOUT 8500
+#define HOST_MSP_TIMEOUT 12000
 
 enum MSPHost {
     HOST_NONE = 0,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -262,8 +262,6 @@ void loop()
                 if (curr.host == HOST_NONE)
                 {
                     curr.host = MSPManager::getSingleton()->getFCVariant();
-                    sys.host_found = millis();
-                    DBGF("[main] Checking FC Variant: %d\n", curr.host);
                 }
                 if (cfg.force_gs)
                 {
@@ -273,9 +271,8 @@ void loop()
                 // Found the host - Ardu's craftname is used for DJI messages, so "INIT" will be everyone's craftname.
                 // Better to use randomly generated names for Ardu and skip this.
             
-                if (sys.now > sys.host_found + FC_BOOT_DELAY && curr.host != HOST_NONE && curr.host != HOST_ARDU)
+                if (curr.host != HOST_NONE && curr.host != HOST_ARDU)
                 {
-                    DBGLN("[main] Checking craftname");
                     MSPManager::getSingleton()->getName(curr.name, sizeof(curr.name));
                 }
                 if (cfg.display_enable)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -230,14 +230,9 @@ void loop()
     if (sys.phase == MODE_HOST_SCAN)
     {
 
-        if ((sys.now > (sys.cycle_scan_begin + HOST_MSP_TIMEOUT)) || (curr.host != HOST_NONE))
+        if ((sys.now > (sys.cycle_scan_begin + HOST_MSP_TIMEOUT)) || (curr.name[0] != '\0') || (curr.host == HOST_ARDU))
         {
-            // End of the host scan - Ardu's craftname is used for DJI messages, so "INIT" will be everyone's craftname.
-            // Better to use randomly generated names for Ardu
-            if (curr.host != HOST_NONE && curr.host != HOST_ARDU)
-            {
-                MSPManager::getSingleton()->getName(curr.name, sizeof(curr.name));
-            }
+            // If we don't have a craft name at this point, let's assign a random string.
             if (curr.name[0] == '\0')
             {
                 String chipIDString = generate_id();
@@ -264,16 +259,31 @@ void loop()
             if (sys.now > sys.display_updated + DISPLAY_CYCLE / 2)
             {
                 delay(100);
-                curr.host = MSPManager::getSingleton()->getFCVariant();
+                if (curr.host == HOST_NONE)
+                {
+                    curr.host = MSPManager::getSingleton()->getFCVariant();
+                    sys.host_found = millis();
+                    DBGF("[main] Checking FC Variant: %d\n", curr.host);
+                }
                 if (cfg.force_gs)
                 {
                     DBGLN("[main] forcing GCS mode");
                     curr.host = HOST_GCS;
                 }
+                // Found the host - Ardu's craftname is used for DJI messages, so "INIT" will be everyone's craftname.
+                // Better to use randomly generated names for Ardu and skip this.
+            
+                if (sys.now > sys.host_found + FC_BOOT_DELAY && curr.host != HOST_NONE && curr.host != HOST_ARDU)
+                {
+                    DBGLN("[main] Checking craftname");
+                    MSPManager::getSingleton()->getName(curr.name, sizeof(curr.name));
+                    DBGF("[main] Craftname returned %s\n", curr.name);
+                }
                 if (cfg.display_enable)
                 {
                     display_draw_progressbar(100 * (millis() - sys.cycle_scan_begin) / HOST_MSP_TIMEOUT);
                 }
+                
                 sys.display_updated = millis();
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -277,13 +277,11 @@ void loop()
                 {
                     DBGLN("[main] Checking craftname");
                     MSPManager::getSingleton()->getName(curr.name, sizeof(curr.name));
-                    DBGF("[main] Craftname returned %s\n", curr.name);
                 }
                 if (cfg.display_enable)
                 {
                     display_draw_progressbar(100 * (millis() - sys.cycle_scan_begin) / HOST_MSP_TIMEOUT);
                 }
-                
                 sys.display_updated = millis();
             }
         }

--- a/src/main.h
+++ b/src/main.h
@@ -56,6 +56,8 @@
 
 // Interval in ms between display updates
 #define DISPLAY_CYCLE 250
+// Interval in ms to allow the FC to boot
+#define FC_BOOT_DELAY 1500
 // Standard MSP serial speed
 #define SERIAL_SPEED 115200
 
@@ -142,6 +144,9 @@ struct system_t {
 
     // Timestamp when the last scan cycle began
     uint32_t cycle_scan_begin;
+
+    // Timestamp when we first found the FC
+    uint32_t host_found;
 
     // Message to display to the user
     char message[20];

--- a/src/main.h
+++ b/src/main.h
@@ -56,8 +56,7 @@
 
 // Interval in ms between display updates
 #define DISPLAY_CYCLE 250
-// Interval in ms to allow the FC to boot
-#define FC_BOOT_DELAY 1500
+
 // Standard MSP serial speed
 #define SERIAL_SPEED 115200
 


### PR DESCRIPTION
This fixes FormationFlight/FormationFlight#44 by moving the craft name check into the display update block and allowing the FC 1500 mS to load it's configuration after we detect it.  I've updated the overall discovery timeout to account for this extra delay.  Ardupilot skips the craftname check still.