### PR TITLE
Update legacy.ini -removed Heltec WiFi LoRa 32 v3 target names

### DIFF
--- a/targets/legacy.ini
+++ b/targets/legacy.ini
@@ -106,7 +106,7 @@ build_flags =
 	${env_common_433.build_flags}
 	${env_Heltec_WiFi_LoRa_32.build_flags}
 	'-D CFG_TARGET_NAME="HT32"'
-	'-D CFG_TARGET_FULLNAME="Heltec WiFi LoRa 32 v1-3 433MHz"'
+	'-D CFG_TARGET_FULLNAME="Heltec WiFi LoRa 32 v1,v2 433MHz"'
 
 [env:diy_LoRa_Heltec_WiFi_LoRa_32_868_via_UART]
 extends = env_common_esp32, env_common_868, env_Heltec_WiFi_LoRa_32
@@ -115,7 +115,7 @@ build_flags =
 	${env_common_868.build_flags}
 	${env_Heltec_WiFi_LoRa_32.build_flags}
 	'-D CFG_TARGET_NAME="HT32"'
-	'-D CFG_TARGET_FULLNAME="Heltec WiFi LoRa 32 v1-3 868MHz"'
+	'-D CFG_TARGET_FULLNAME="Heltec WiFi LoRa 32 v1,v2 868MHz"'
 
 [env:diy_LoRa_Heltec_WiFi_LoRa_32_915_via_UART]
 extends = env_common_esp32, env_common_915, env_Heltec_WiFi_LoRa_32
@@ -124,7 +124,7 @@ build_flags =
 	${env_common_915.build_flags}
 	${env_Heltec_WiFi_LoRa_32.build_flags}
 	'-D CFG_TARGET_NAME="HT32"'
-	'-D CFG_TARGET_FULLNAME="Heltec WiFi LoRa 32 v1-3 915MHz"'
+	'-D CFG_TARGET_FULLNAME="Heltec WiFi LoRa 32 v1,v2 915MHz"'
  
 [env:diy_LoRa_lilygo10_433_via_UART]
 extends = env_common_esp32, env_common_433, env_lilygo10


### PR DESCRIPTION
The Heltec WiFi Lora32 v3 uses a different CPU than the V1,v2.

Updated CFG_TARGET_FULLNAME values from:
Heltec WiFi LoRa 32 v1-3*
to:
Heltec WiFi LoRa 32 v1,v2*