### PR TITLE
Remove unnecessary conversion when sending loc

### DIFF
--- a/src/lib/Display/Display.cpp
+++ b/src/lib/Display/Display.cpp
@@ -269,7 +269,7 @@ void display_draw_status(system_t *sys)
             {
                 display.drawString(0, 24, "A " + String(loc.alt) + "m");
                 display.drawString(0, 34, "S " + String(loc.groundSpeed / 100) + "m/s");
-                display.drawString(0, 44, "C " + String(loc.groundCourse / 10) + "°");
+                display.drawString(0, 44, "C " + String(loc.groundCourse) + "°");
             }
             else
             {

--- a/src/lib/Radios/RadioManager.cpp
+++ b/src/lib/Radios/RadioManager.cpp
@@ -40,7 +40,7 @@ air_type0_t RadioManager::prepare_packet()
     switch (air_0.extra_type)
     {
     case 0:
-        air_0.extra_value = loc.groundCourse / 10;
+        air_0.extra_value = loc.groundCourse;  // location.groundCourse is in degrees so we don't need to convert before sending
         break;
 
     case 1:


### PR DESCRIPTION
This should fix the incorrect relative heading displayed in Inav. 