### PR TITLE
Set all our mod params twice, use long interleaving

### DIFF
--- a/src/lib/Radios/LoRa_SX128X.cpp
+++ b/src/lib/Radios/LoRa_SX128X.cpp
@@ -55,9 +55,15 @@ int LoRa_SX128X::begin() {
         DBGF("failed to init sx1280: %d\n", state);
         while (true) {}
     }
-    // We appear to need to set this twice
-    radio->setOutputPower(LORA_POWER);
+    // We appear to need to set these twice?
     radio->setHighSensitivityMode(true);
+    radio->setFrequency(FREQUENCY);
+    radio->setBandwidth(BANDWIDTH);
+    radio->setSpreadingFactor(SPREADING_FACTOR);
+    radio->setCodingRate(CODING_RATE, LONG_INTERLEAVING);
+    radio->setSyncWord(SYNC_WORD);
+    radio->setOutputPower(LORA_POWER);
+    radio->setPreambleLength(PREAMBLE_LENGTH);
     //radio->setCRC(0);
     #ifdef LORA_PIN_TXEN
     radio->setRfSwitchPins(LORA_PIN_RXEN, LORA_PIN_TXEN);

--- a/src/lib/Radios/LoRa_SX128X.h
+++ b/src/lib/Radios/LoRa_SX128X.h
@@ -11,6 +11,7 @@
 #define CODING_RATE 6 // 4/6 CR
 #define SYNC_WORD 0x17 // Arbitrarily chosen
 #define PREAMBLE_LENGTH 12 // symbols
+#define LONG_INTERLEAVING true
 
 #define RECEIVE_TIMEOUT LORA_M3_SLOT_SPACING * LORA_M3_NODES - 1
 #endif


### PR DESCRIPTION
This improves our low RSSI behavior from failsafe around -93dBm to working at 100% LQ at -105dBm. Haven't tested further down than that, but we should be able to get -109dBm before failsafe.

This should improve range dramatically.