### PR TITLE
Add ExpressLRS 433MHz targets

### DIFF
--- a/targets/expresslrs.ini
+++ b/targets/expresslrs.ini
@@ -18,6 +18,26 @@ build_flags =
 	-D IO_LED_PIN=16
 	-D PIN_BUTTON=0
 
+; ELRS 433MHz receivers
+[env_expresslrs_rx_433]
+extends = env_common_esp82xx
+build_flags = 
+	${env_common_esp82xx.build_flags}
+	; MSP UART
+	-D SERIAL_PIN_RX=3
+	-D SERIAL_PIN_TX=1
+	; LoRa Config
+	-D LORA_PIN_MISO=12
+	-D LORA_PIN_MOSI=13
+	-D LORA_PIN_SCK=14
+	-D LORA_PIN_CS=15
+	-D LORA_PIN_DIO0=4
+	-D LORA_PIN_RST=2
+	-D LORA_POWER=10
+	; Human Interface
+	-D IO_LED_PIN=16
+	-D PIN_BUTTON=0
+
 ; ELRS 2400MHz receivers
 [env_expresslrs_rx_2400]
 extends = env_common_esp82xx
@@ -37,6 +57,16 @@ build_flags =
 	; Human Interface
 	-D IO_LED_PIN=16
 	-D PIN_BUTTON=0
+[env:expresslrs_rx_433_via_UART]
+extends = env_expresslrs_rx_433, env_common_433
+build_flags = 
+	${env_expresslrs_rx_433.build_flags}
+	${env_common_433.build_flags}
+	'-D CFG_TARGET_NAME="ELRS433"'
+	'-D CFG_TARGET_FULLNAME="ExpressLRS 433MHz RX"'
+
+[env:expresslrs_rx_433_via_WiFi]
+extends = env:expresslrs_rx_433_via_UART
 
 ; 868MHz (Example: HappyModel ES900RX)
 [env:expresslrs_rx_868_via_UART]


### PR DESCRIPTION
Adds 433MHz elrs targets (uart and wifi, no diversity). Tested on cheap Aliexpress hardware.