### PR TITLE
Add 2MB/1MB flash layouts for ELRS builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -64,15 +64,31 @@ build_flags =
 	-D PLATFORM_ESP32
 	-D WIFI_CONFIG
 
-[env_common_esp82xx]
+[env_common_esp82xx_base]
 platform = espressif8266@^4.2.0
 board = esp8285
 ;monitor_filters = esp8266_exception_decoder
 lib_deps =
 	${env.lib_deps}
-build_flags = 
+build_flags =
 	-D PLATFORM_ESP8266
 	-D WIFI_CONFIG
+
+[env_common_esp82xx]
+extends = env_common_esp82xx_base
+board_build.flash_size = 2MB
+board_build.ldscript = eagle.flash.2m1m.ld
+build_flags =
+	${env_common_esp82xx_base.build_flags}
+	-D FLASH_LAYOUT_2M1M
+
+[env_common_esp82xx_1m]
+extends = env_common_esp82xx_base
+board_build.flash_size = 1MB
+board_build.ldscript = eagle.flash.1m256.ld
+build_flags =
+	${env_common_esp82xx_base.build_flags}
+	-D FLASH_LAYOUT_1M256
 
 [env_common_433]
 build_flags = 

--- a/targets/diy_espnow.ini
+++ b/targets/diy_espnow.ini
@@ -1,7 +1,7 @@
 [env:diy_ESPNOW_esp8266_via_UART]
-extends = env_common_esp82xx
+extends = env_common_esp82xx_1m
 build_flags = 
-	${env_common_esp82xx.build_flags}
+	${env_common_esp82xx_1m.build_flags}
 	'-D CFG_TARGET_NAME="ESP8266"'
 	'-D CFG_TARGET_FULLNAME="ESP8266"'
 	-D SERIAL_PIN_RX=3


### PR DESCRIPTION
This changes the default flash layout for ESP82xx/ELRS builds to 2M/1M from 1M256 (current default from platformio), and retains the 1M256 layout for ESP8266 ESPNow targets (which I'm assuming are more likely to be somewhat random as to specific ESP82XX, so no predictable flash size).
Aim is to enable some future changes that will fail the OTA flash check with current default flash layout.  The ELRS receivers I have all report a minimum of 2MB flash (cheap 433, EP1 2.4, ES900), and this change has been tested with them successfully - but happy to be corrected / have this PR rejected if there are in fact 1MB ELRS targets out there.
I have also tested the ESPNow 1MB build with an old 1MB esp8266 - uart and wifi uploads both work fine.