### PR TITLE
Add editable aircraft name in WebUI

### DIFF
--- a/html/main.js
+++ b/html/main.js
@@ -64,7 +64,7 @@ function Sidebar({ url, show, systemStatus }) {
 
     <div class="flex flex-1 flex-col">
       <${NavLink} title="Dashboard" icon=${Icons.home} href="/" url=${url} />
-      <!--<${NavLink} title="Settings" icon=${Icons.settings} href="/settings" url=${url} />-->
+      <${NavLink} title="Settings" icon=${Icons.settings} href="/settings" url=${url} />
       <${NavLink} title="Update" icon=${Icons.upArrowBox} href="/update" url=${url} />
     <//>
   <//>
@@ -161,22 +161,22 @@ function Main() {
 }
 
 function Settings() {
-  const [settings, setSettings] = useState(null);
+  const [name, setName] = useState(null);
   const [saveResult, setSaveResult] = useState(null);
   const refresh = () => fetch(ENDPOINT_PREFIX + '/system/status')
     .then(r => r.json())
-    .then(r => setSettings(r));
+    .then(r => setName(r.device_name || ''));
   useEffect(refresh, []);
 
-  const mksetfn = k => (v => setSettings(x => Object.assign({}, x, { [k]: v })));
-  const onsave = () => fetch(ENDPOINT_PREFIX + '/system/status', {
-    method: 'GET'/*, body: JSON.stringify(settings)*/
-  }).then(r => r.json())
-    .then(r => setSaveResult(r))
-    .then(refresh);
+  const onsave = () => {
+    const body = new URLSearchParams();
+    body.append('name', name);
+    fetch(ENDPOINT_PREFIX + '/system/name', { method: 'POST', body })
+      .then(r => r.text().then(text => setSaveResult({ status: r.ok, message: r.ok ? 'Saved' : text })))
+      .then(refresh);
+  };
 
-  if (!settings) return '';
-  const logOptions = [[0, 'Disable'], [1, 'Error'], [2, 'Info'], [3, 'Debug']];
+  if (name === null) return '';
   return html`
 <div class="m-4 grid grid-cols-1 gap-4 md:grid-cols-2">
 
@@ -188,11 +188,9 @@ function Settings() {
       ${saveResult && html`<${Notification} ok=${saveResult.status}
         text=${saveResult.message} close=${() => setSaveResult(null)} />`}
 
-      <${Setting} title="Enable Logs" value=${settings.log_enabled} setfn=${mksetfn('log_enabled')} type="switch" />
-      <${Setting} title="Log Level" value=${settings.log_level} setfn=${mksetfn('log_level')} type="select" addonLeft="0-3" disabled=${!settings.log_enabled} options=${logOptions}/>
-      <${Setting} title="Brightness" value=${settings.brightness} setfn=${mksetfn('brightness')} type="number" addonRight="%" />
-      <${Setting} title="Device Name" value=${settings.device_name} setfn=${mksetfn('device_name')} type="" />
-      <div class="mb-1 mt-3 flex place-content-end"><${Button} icon=${Icons.save} onclick=${onsave} title="Save Settings" /><//>
+      <${Setting} title="Aircraft Name" value=${name} setfn=${setName} type="" placeholder="Leave empty for auto" />
+      <p class="mt-2 text-xs text-gray-400">Overrides the flight controller craft name. Leave empty to use the FC name (or an auto-generated one).</p>
+      <div class="mb-1 mt-3 flex place-content-end"><${Button} icon=${Icons.save} onclick=${onsave} title="Save" /><//>
     <//>
   <//>
 <//>`;
@@ -279,7 +277,7 @@ const App = function () {
   <div class="${showSidebar && 'pl-72'} transition-all duration-300 transform">
     <${Router} onChange=${ev => { setUrl(ev.url); setShowSidebar(window.innerWidth > 1200); }} history=${History.createHashHistory()} >
       <${Main} default=${true} />
-      <!--<${Settings} path="settings" />-->
+      <${Settings} path="settings" />
       <${Update} path="update" />
     <//>
   <//>

--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,18 @@
 
 FormationFlight provides FPV pilots with inter-UAS positioning & telemetry, enabling formation flights, chase footage, and ground station coordination with ease. Spiritual successor to the [iNav Radar](https://github.com/OlivierC-FR/ESP32-INAV-Radar) project, FormationFlight adds many improvements including faster update rates, more users, encryption, and smaller, lighter hardware originally developed for the [ExpressLRS project](https://github.com/ExpressLRS/ExpressLRS).
 
+## This Fork
+
+This fork adds an **editable aircraft name in the WebUI**. Upstream derives the displayed name solely from the connected flight controller's craft name (falling back to a random ID when there is no FC). On a repurposed ExpressLRS receiver used standalone that often leaves you with an unhelpful auto-generated name.
+
+With this change you can set a name directly on the device:
+
+1. Connect to the device's WiFi AP (`iNav Radar-…`, password `inavradar`) and open the WebUI.
+2. Go to **Settings** → **Aircraft Name**, enter a name, and **Save**.
+3. Leave the field empty to fall back to the automatic behaviour (FC craft name, then a random ID).
+
+A non-empty name always wins over the flight controller's craft name, is stored in the device config (persists across reboots), and applies live without a reboot. The feature is compiled into the standard firmware, including all ExpressLRS receiver targets.
+
 ## Getting Started
 
 Visit the [FormationFlight Getting Started](https://formationflight.org/getting-started/) page!

--- a/src/lib/ConfigHandler.cpp
+++ b/src/lib/ConfigHandler.cpp
@@ -34,7 +34,7 @@ void config_init(bool forcedefault)
         ((char *)&cfg)[i] = data;
     }
 
-    if (true || cfg.version != VERSION_CONFIG || forcedefault)
+    if (cfg.version != VERSION_CONFIG || forcedefault)
     {
         cfg.version = VERSION_CONFIG;
         cfg.force_gs = false;
@@ -45,6 +45,7 @@ void config_init(bool forcedefault)
         cfg.msp_after_tx_delay = LORA_M3_MSP_AFTER_TX_DELAY;
 
         cfg.display_enable = 1;
+        cfg.name_override[0] = '\0';
         config_save();
     }
 }

--- a/src/lib/ConfigHandler.h
+++ b/src/lib/ConfigHandler.h
@@ -4,7 +4,7 @@
 
 
 void handleConfigMessage(Stream& input_source, String message);
-void config_save(config_t *cfg);
+void config_save();
 void config_init(bool forcedefault = 0);
 void config_clear();
 

--- a/src/lib/WiFi/WiFiManager.cpp
+++ b/src/lib/WiFi/WiFiManager.cpp
@@ -17,6 +17,7 @@
 #include "../Power/PowerManager.h"
 #include "../Statistics/StatsManager.h"
 #include "../Cryptography/CryptoManager.h"
+#include "../ConfigHandler.h"
 #include "webcontent.h"
 
 WiFiManager::WiFiManager()
@@ -61,6 +62,23 @@ WiFiManager::WiFiManager()
     server->on("/system/delay", HTTP_POST, [](AsyncWebServerRequest *request) {
         request->send(200, "text/plain", "OK");
         delayMicroseconds(1000);
+    });
+    // Set the user-defined aircraft name (persisted to config). Empty reverts to auto.
+    server->on("/system/name", HTTP_POST, [](AsyncWebServerRequest *request) {
+        if (!request->hasParam("name", true)) {
+            request->send(400, "text/plain", "need parameter name");
+            return;
+        }
+        String name = request->getParam("name", true)->value();
+        strncpy(cfg.name_override, name.c_str(), sizeof(cfg.name_override) - 1);
+        cfg.name_override[sizeof(cfg.name_override) - 1] = '\0';
+        config_save();
+        // Apply immediately so the change shows without a reboot (clearing takes effect on reboot).
+        if (cfg.name_override[0] != '\0') {
+            strncpy(curr.name, cfg.name_override, sizeof(curr.name) - 1);
+            curr.name[sizeof(curr.name) - 1] = '\0';
+        }
+        request->send(200, "text/plain", "OK");
     });
     // RadioManager
     server->on("/radiomanager/status", HTTP_GET, [](AsyncWebServerRequest *request) {
@@ -241,6 +259,7 @@ void handleSystemStatus(AsyncWebServerRequest *request)
     doc["uptimeMilliseconds"] = millis();
     doc["phase"] = sys.phase;
     doc["name"] = curr.name;
+    doc["device_name"] = cfg.name_override;
     doc["longName"] = generate_id();
     doc["host"] = host_name[MSPManager::getSingleton()->getFCVariant()];
     doc["state"] = MSPManager::getSingleton()->getState();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -232,8 +232,14 @@ void loop()
 
         if ((sys.now > (sys.cycle_scan_begin + HOST_MSP_TIMEOUT)) || (curr.name[0] != '\0') || (curr.host == HOST_ARDU))
         {
+            // A user-set name (from the WebUI) always wins.
+            if (cfg.name_override[0] != '\0')
+            {
+                strncpy(curr.name, cfg.name_override, sizeof(curr.name) - 1);
+                curr.name[sizeof(curr.name) - 1] = '\0';
+            }
             // If we don't have a craft name at this point, let's assign a random string.
-            if (curr.name[0] == '\0')
+            else if (curr.name[0] == '\0')
             {
                 String chipIDString = generate_id();
                 for (int i = 0; i < 3; i++)

--- a/src/main.h
+++ b/src/main.h
@@ -18,7 +18,7 @@
 // -------- GENERAL
 
 #define PRODUCT_NAME "FormationFlight"
-#define VERSION_CONFIG 400
+#define VERSION_CONFIG 401
 #define START_DELAY 1000
 
 // These are injected at build time by build_flags.py, these are here to make syntax highlighting happy
@@ -106,6 +106,9 @@ struct config_t {
     int16_t msp_after_tx_delay;
 
     bool display_enable;
+
+    // User-set aircraft name (WebUI). Empty = auto (FC craft name, then random).
+    char name_override[16];
 };
 
 struct system_t {


### PR DESCRIPTION
Adds a user-settable aircraft name that is stored in device config and overrides the flight controller craft name (empty = auto: FC name, then random). Useful for repurposed ELRS receivers with no FC craft name.

- main.h: add name_override[16] to config_t; bump VERSION_CONFIG to 401
- ConfigHandler.cpp: fix config being reset to defaults on every boot (the `if (true || ...)` guard), default name_override to empty
- ConfigHandler.h: correct stale config_save() declaration
- main.cpp: user-set name always wins during host scan
- WiFiManager.cpp: add POST /system/name endpoint (persists + applies live), expose device_name in /system/status
- main.js: reinstate Settings page as a focused Aircraft Name editor